### PR TITLE
Respect the user's state param if passed in as a query param

### DIFF
--- a/lib/ueberauth/strategy/workos.ex
+++ b/lib/ueberauth/strategy/workos.ex
@@ -62,8 +62,7 @@ defmodule Ueberauth.Strategy.WorkOS do
   If you use an email address to determine the connection selector, then it is advisable to use the
   same email address as the `login_hint`.
   """
-  use Ueberauth.Strategy,
-    ignores_csrf_attack: true
+  use Ueberauth.Strategy, ignores_csrf_attack: true
 
   alias Ueberauth.Auth.Credentials
   alias Ueberauth.Auth.Extra
@@ -82,7 +81,13 @@ defmodule Ueberauth.Strategy.WorkOS do
       |> with_connection_selector(conn)
       |> with_param(:domain_hint, conn)
       |> with_param(:login_hint, conn)
-      |> with_state_param(conn)
+
+    # Add the state param from the conn params if one exists.
+    # This lets callers use the state param to pass additional information to the callback.
+    params =
+      if value = conn.params[to_string(:state)],
+        do: Keyword.put(params, :state, value),
+        else: with_state_param(params, conn)
 
     opts = oauth_client_options_from_conn(conn)
     redirect!(conn, OAuth.authorize_url!(params, opts))

--- a/test/ueberauth/strategy/workos_test.exs
+++ b/test/ueberauth/strategy/workos_test.exs
@@ -94,6 +94,15 @@ defmodule Ueberauth.Strategy.WorkOSTest do
 
     # State
 
+    test "allows a custom state parameter", %{conn: conn} do
+      # I want a state param on the request to override the private state param
+      conn = put_param(conn, "state", "custom_state")
+      conn = WorkOS.handle_request!(conn)
+      assert {302, headers, _body} = sent_resp(conn)
+      assert %{"location" => sign_in_page} = Enum.into(headers, %{})
+      assert sign_in_page =~ "state=custom_state"
+    end
+
     test "sets state cookie", %{conn: conn} do
       conn = WorkOS.handle_request!(conn)
       assert {_status, headers, _body} = sent_resp(conn)


### PR DESCRIPTION
This will allow us to use the the WorkOS state param as documented at https://workos.com/docs/reference/sso/get-authorization-url. The state param in the Ueberauth request query string will get passed through to the WorkOS API call. It gets passed back to us in the callback then.